### PR TITLE
fix `parse_confluence_by_page_id` again

### DIFF
--- a/chatbot/confluence_interaction.py
+++ b/chatbot/confluence_interaction.py
@@ -36,7 +36,8 @@ def parse_confluence_by_page_id(id: int | str) -> list | str:
         for i in soup.find_all():
             if i.find("ac:parameter"):
                 i.decompose()
-        for i in soup.find_all(["p", "li", "ul"]):
+        for i in soup.find_all(["p", "li"]):
+            if i.name == 'li': text += '• '
             text += i.get_text() + "\n\n"
         if len(text) == 0:
             return f"Информация находится по ссылке: {page_link}"

--- a/chatbot/confluence_interaction.py
+++ b/chatbot/confluence_interaction.py
@@ -37,7 +37,7 @@ def parse_confluence_by_page_id(id: int | str) -> list | str:
             if i.find("ac:parameter"):
                 i.decompose()
         for i in soup.find_all(["p", "li"]):
-            if i.name == "li": text += '• '
+            if i.name == "li": text += "• "
             text += i.get_text() + "\n\n"
         if len(text) == 0:
             return f"Информация находится по ссылке: {page_link}"

--- a/chatbot/confluence_interaction.py
+++ b/chatbot/confluence_interaction.py
@@ -37,7 +37,7 @@ def parse_confluence_by_page_id(id: int | str) -> list | str:
             if i.find("ac:parameter"):
                 i.decompose()
         for i in soup.find_all(["p", "li"]):
-            if i.name == 'li': text += '• '
+            if i.name == "li": text += '• '
             text += i.get_text() + "\n\n"
         if len(text) == 0:
             return f"Информация находится по ссылке: {page_link}"


### PR DESCRIPTION
Если справочная информация содержит список, он маркируется, тэг "ul" не парсится, т. к. повторно текст не должен отображаться.